### PR TITLE
Update to latest rode chart in skaffold

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -16,7 +16,7 @@ require (
 	github.com/onsi/ginkgo v1.14.2
 	github.com/onsi/gomega v1.10.3
 	github.com/pquerna/cachecontrol v0.0.0-20201205024021-ac21108117ac // indirect
-	github.com/rode/grafeas-elasticsearch v0.3.0
+	github.com/rode/grafeas-elasticsearch v0.4.0
 	go.uber.org/zap v1.16.0
 	golang.org/x/net v0.0.0-20210119194325-5f4716e94777 // indirect
 	golang.org/x/oauth2 v0.0.0-20210201163806-010130855d6c

--- a/go.sum
+++ b/go.sum
@@ -279,6 +279,8 @@ github.com/prometheus/procfs v0.0.0-20190507164030-5867b95ac084/go.mod h1:TjEm7z
 github.com/prometheus/tsdb v0.7.1/go.mod h1:qhTCs0VvXwvX/y3TZrWD7rabWM+ijKTux40TwIPHuXU=
 github.com/rode/grafeas-elasticsearch v0.3.0 h1:5PGUwFaWVjTxjp4Vz9ZABsyYLoF3lZt2zWmwDk5re0c=
 github.com/rode/grafeas-elasticsearch v0.3.0/go.mod h1:uQKMdz9DlTj0zYTuGVGr0rcIYFAgVnYgXoCYMs/U7E0=
+github.com/rode/grafeas-elasticsearch v0.4.0 h1:ZBDEbY3SfbT1QRaiMsGNYSGpghmcHWkD/syEg8us60w=
+github.com/rode/grafeas-elasticsearch v0.4.0/go.mod h1:uQKMdz9DlTj0zYTuGVGr0rcIYFAgVnYgXoCYMs/U7E0=
 github.com/rogpeppe/fastuuid v0.0.0-20150106093220-6724a57986af/go.mod h1:XWv6SoW27p1b0cqNHllgS5HIMJraePCO15w5zCzIWYg=
 github.com/rogpeppe/fastuuid v1.2.0/go.mod h1:jVj6XXZzXRy/MSR5jhDC/2q6DgLz+nrA6LYCDYWNEvQ=
 github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=

--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -11,7 +11,7 @@ deploy:
     releases:
       - name: rode
         chartPath: rode/rode
-        version: 0.0.5
+        version: 0.0.7
         remote: true
         wait: true
         artifactOverrides:


### PR DESCRIPTION
Update skaffold to reference latest rode chart version

Use the latest grafeas-elasticsearch version in `go.mod`

If this is totally wrong, please let me know :)


