### PR TITLE
Query resources against occurrences alias

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -39,7 +39,7 @@ import (
 )
 
 const (
-	rodeElasticsearchOccurrencesIndex = "grafeas-v1beta1-rode-occurrences"
+	rodeElasticsearchOccurrencesAlias = "grafeas-rode-occurrences"
 	rodeElasticsearchPoliciesIndex    = "rode-v1alpha1-policies"
 )
 
@@ -174,7 +174,7 @@ func (r *rodeServer) ListResources(ctx context.Context, request *pb.ListResource
 	log.Debug("es request payload", zap.Any("payload", requestJSON))
 	res, err := r.esClient.Search(
 		r.esClient.Search.WithContext(ctx),
-		r.esClient.Search.WithIndex(rodeElasticsearchOccurrencesIndex),
+		r.esClient.Search.WithIndex(rodeElasticsearchOccurrencesAlias),
 		r.esClient.Search.WithBody(encodedBody),
 		r.esClient.Search.WithSize(1000),
 	)

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -443,7 +443,7 @@ var _ = Describe("rode server", func() {
 				It("should query the Rode occurrences index", func() {
 					actualRequest := esTransport.receivedHttpRequests[1]
 
-					Expect(actualRequest.URL.Path).To(Equal("/grafeas-v1beta1-rode-occurrences/_search"))
+					Expect(actualRequest.URL.Path).To(Equal("/grafeas-rode-occurrences/_search"))
 				})
 
 				It("should take the first 1000 matches", func() {


### PR DESCRIPTION
This is to account for the changes from https://github.com/rode/grafeas-elasticsearch/pull/59 and subsequent PRs. Now that we have aliases fronting index names, we don't need to depend on the versioned index name directly. 