### PR TITLE
Generic resource followup

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -22,7 +22,6 @@ import (
 	"fmt"
 	"io"
 	"net/http"
-	"strings"
 
 	"github.com/elastic/go-elasticsearch/v7"
 	"github.com/gogo/protobuf/protoc-gen-gogo/generator"
@@ -96,7 +95,11 @@ func (r *rodeServer) batchCreateGenericResources(ctx context.Context, occurrence
 	visitedResources := map[string]bool{}
 	var resourceNames []string
 	for _, x := range occurrenceRequest.Occurrences {
-		resourceName := strings.Split(x.Resource.Uri, "@")[0]
+		uriParts, err := parseResourceUri(x.Resource.Uri)
+		if err != nil {
+			return err
+		}
+		resourceName := uriParts.name
 		if _, ok := visitedResources[resourceName]; ok {
 			continue
 		}

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -469,6 +469,16 @@ var _ = Describe("rode server", func() {
 				})
 			})
 
+			When("an error occurs determining the resource uri version", func() {
+				BeforeEach(func() {
+					occurrence.Resource.Uri = gofakeit.URL()
+				})
+
+				It("should return an error", func() {
+					Expect(actualError).To(HaveOccurred())
+				})
+			})
+
 			When("the generic resources already exist", func() {
 				BeforeEach(func() {
 					esTransport.preparedHttpResponses[0] = &http.Response{
@@ -1551,7 +1561,7 @@ func createRandomOccurrence(kind grafeas_common_proto.NoteKind) *grafeas_proto.O
 	return &grafeas_proto.Occurrence{
 		Name: gofakeit.LetterN(10),
 		Resource: &grafeas_proto.Resource{
-			Uri: gofakeit.URL(),
+			Uri: fmt.Sprintf("%s@sha256:%s", gofakeit.URL(), gofakeit.LetterN(10)),
 		},
 		NoteName:    gofakeit.LetterN(10),
 		Kind:        kind,

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -33,6 +33,7 @@ import (
 	"github.com/golang/protobuf/proto"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+	. "github.com/onsi/gomega/gstruct"
 	"github.com/rode/grafeas-elasticsearch/go/v1beta1/storage/filtering"
 	"github.com/rode/rode/config"
 	"github.com/rode/rode/mocks"
@@ -174,19 +175,81 @@ var _ = Describe("rode server", func() {
 		})
 
 		Context("Rode Elasticsearch indices", func() {
-			BeforeEach(func() {
+			var actualError error
+			assertIndexRequestHasMappings := func(request *http.Request) {
+				payload := map[string]interface{}{}
+				readResponseBody(request, &payload)
+				Expect(payload).To(MatchAllKeys(Keys{
+					"mappings": MatchAllKeys(Keys{
+						"_meta": MatchAllKeys(Keys{
+							"type": Equal("rode"),
+						}),
+						"dynamic_templates": ConsistOf(MatchAllKeys(Keys{
+							"strings_as_keywords": MatchAllKeys(Keys{
+								"match_mapping_type": Equal("string"),
+								"mapping": MatchAllKeys(Keys{
+									"norms": Equal(false),
+									"type":  Equal("keyword"),
+								}),
+							}),
+						})),
+					}),
+				}))
+			}
+
+			JustBeforeEach(func() {
 				grafeasProjectsClient.EXPECT().GetProject(gomock.Any(), gomock.Any())
-				_, _ = NewRodeServer(logger, grafeasClient, grafeasProjectsClient, opaClient, esClient, mockFilterer, elasticsearchConfig)
+				_, actualError = NewRodeServer(logger, grafeasClient, grafeasProjectsClient, opaClient, esClient, mockFilterer, elasticsearchConfig)
 			})
 
 			It("should create an index for policies", func() {
 				Expect(esTransport.receivedHttpRequests[0].Method).To(Equal(http.MethodPut))
 				Expect(esTransport.receivedHttpRequests[0].URL.Path).To(Equal("/rode-v1alpha1-policies"))
+				assertIndexRequestHasMappings(esTransport.receivedHttpRequests[0])
 			})
 
 			It("should create an index for generic resources", func() {
 				Expect(esTransport.receivedHttpRequests[1].Method).To(Equal(http.MethodPut))
 				Expect(esTransport.receivedHttpRequests[1].URL.Path).To(Equal("/rode-v1alpha1-generic-resources"))
+				assertIndexRequestHasMappings(esTransport.receivedHttpRequests[1])
+			})
+
+			When("an unexpected status code is returned from the create index call", func() {
+				BeforeEach(func() {
+					esTransport.preparedHttpResponses[0].StatusCode = http.StatusInternalServerError
+				})
+
+				It("should return an error", func() {
+					Expect(actualError).To(HaveOccurred())
+				})
+
+				It("should not make any further requests", func() {
+					Expect(esTransport.receivedHttpRequests).To(HaveLen(1))
+				})
+			})
+
+			When("an error occurs during the request", func() {
+				BeforeEach(func() {
+					esTransport.actions = []func(req *http.Request) (*http.Response, error){
+						func(req *http.Request) (*http.Response, error) {
+							return nil, errors.New(gofakeit.Word())
+						},
+					}
+				})
+
+				It("should return an error", func() {
+					Expect(actualError).To(HaveOccurred())
+				})
+			})
+
+			When("the index already exists", func() {
+				BeforeEach(func() {
+					esTransport.preparedHttpResponses[0].StatusCode = http.StatusBadRequest
+				})
+
+				It("should not return an error", func() {
+					Expect(actualError).NotTo(HaveOccurred())
+				})
 			})
 		})
 
@@ -661,6 +724,7 @@ var _ = Describe("rode server", func() {
 					Expect(esTransport.receivedHttpRequests[2].Method).To(Equal(http.MethodGet))
 					Expect(esTransport.receivedHttpRequests[2].URL.Path).To(Equal(fmt.Sprintf("/%s/_search", rodeElasticsearchGenericResourcesIndex)))
 					Expect(esTransport.receivedHttpRequests[2].URL.Query().Get("size")).To(Equal(strconv.Itoa(maxPageSize)))
+					Expect(esTransport.receivedHttpRequests[2].URL.Query().Get("sort")).To(Equal("name:asc"))
 
 					body := readEsSearchResponse(esTransport.receivedHttpRequests[2])
 
@@ -680,6 +744,54 @@ var _ = Describe("rode server", func() {
 					}
 
 					Expect(actualNames).To(ConsistOf(expectedNames))
+				})
+
+				When("a filter is provided", func() {
+					var (
+						expectedFilter string
+					)
+
+					BeforeEach(func() {
+						expectedFilter = gofakeit.LetterN(10)
+						listRequest.Filter = expectedFilter
+					})
+
+					When("the filter is valid", func() {
+						var expectedQuery *filtering.Query
+
+						BeforeEach(func() {
+							expectedQuery = &filtering.Query{
+								Term: &filtering.Term{
+									gofakeit.LetterN(10): gofakeit.LetterN(10),
+								},
+							}
+							mockFilterer.EXPECT().ParseExpression(expectedFilter).Return(expectedQuery, nil)
+						})
+
+						It("should include the filter query in the request body", func() {
+							body := readEsSearchResponse(esTransport.receivedHttpRequests[2])
+
+							Expect(body).To(Equal(&esSearch{
+								Query: expectedQuery,
+							}))
+						})
+					})
+
+					When("the filter is invalid", func() {
+						BeforeEach(func() {
+							mockFilterer.EXPECT().ParseExpression(expectedFilter).Return(nil, errors.New(gofakeit.Word()))
+						})
+
+						It("should return an error", func() {
+							Expect(actualError).To(HaveOccurred())
+						})
+
+						It("should set a gRPC status", func() {
+							status := getGRPCStatusFromError(actualError)
+
+							Expect(status.Code()).To(Equal(codes.Internal))
+						})
+					})
 				})
 
 				When("an unexpected status code is returned from the search", func() {

--- a/server/util.go
+++ b/server/util.go
@@ -1,3 +1,17 @@
+// Copyright 2021 The Rode Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package server
 
 import (

--- a/server/util.go
+++ b/server/util.go
@@ -1,0 +1,55 @@
+package server
+
+import (
+	"fmt"
+	"regexp"
+)
+
+var (
+	resourceUriPatterns = []*regexp.Regexp{
+		// Docker images
+		regexp.MustCompile("(?P<name>.+)(@sha256:)(?P<version>.+)"),
+		// Git repositories
+		regexp.MustCompile("^(git:/{2})(?P<name>.+)@(?P<version>.+)"),
+		// Maven packages
+		regexp.MustCompile("^(gav:/{2})(?P<name>.+):(?P<version>.+)"),
+		// Files
+		regexp.MustCompile("^(file:/{2}sha256:)(?P<version>.+):(?P<name>.+)"),
+		// NPM packages
+		regexp.MustCompile("^(npm:/{2})(?P<name>.+):(?P<version>.+)"),
+		// NuGet packages
+		regexp.MustCompile("^(nuget:/{2})(?P<name>.+):(?P<version>.+)"),
+		// pip packages
+		regexp.MustCompile("^(pip:/{2})(?P<name>.+):(?P<version>.+)"),
+		// Debian packages
+		regexp.MustCompile("^(deb:/{2}).*:(?P<name>.+):(?P<version>.+)"),
+		// RPM packages
+		regexp.MustCompile("^(rpm:/{2}).*:(?P<name>.+):(?P<version>.+)"),
+	}
+)
+
+type resourceUriComponents struct {
+	name    string
+	version string
+}
+
+func parseResourceUri(uri string) (*resourceUriComponents, error) {
+	var resourceRegex *regexp.Regexp
+
+	for _, pattern := range resourceUriPatterns {
+		if pattern.MatchString(uri) {
+			resourceRegex = pattern
+			break
+		}
+	}
+
+	if resourceRegex == nil {
+		return nil, fmt.Errorf("unable to determine resource type for uri: %s", uri)
+	}
+
+	matches := resourceRegex.FindStringSubmatch(uri)
+	name := matches[resourceRegex.SubexpIndex("name")]
+	version := matches[resourceRegex.SubexpIndex("version")]
+
+	return &resourceUriComponents{name, version}, nil
+}

--- a/server/util_test.go
+++ b/server/util_test.go
@@ -1,3 +1,17 @@
+// Copyright 2021 The Rode Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package server
 
 import (

--- a/server/util_test.go
+++ b/server/util_test.go
@@ -1,0 +1,84 @@
+package server
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/ginkgo/extensions/table"
+
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("util", func() {
+	Describe("parseResourceUri", func() {
+		DescribeTable("valid resource types", func(resourceUri string, expected *resourceUriComponents) {
+			actual, err := parseResourceUri(resourceUri)
+
+			Expect(err).NotTo(HaveOccurred())
+			Expect(actual).To(Equal(expected))
+		},
+			Entry("Docker image", "https://gcr.io/scanning-customer/dockerimage@sha256:244fd47e07d1004f0aed9c156aa09083c82bf8944eceb67c946ff7430510a77b", &resourceUriComponents{
+				name:    "https://gcr.io/scanning-customer/dockerimage",
+				version: "244fd47e07d1004f0aed9c156aa09083c82bf8944eceb67c946ff7430510a77b",
+			}),
+			Entry("Debian package", "deb://lucid:i386:acl:2.2.49-2", &resourceUriComponents{
+				name:    "acl",
+				version: "2.2.49-2",
+			}),
+			Entry("Debian package without a specified distribution", "deb://arm64:build-essential:12.9", &resourceUriComponents{
+				name:    "build-essential",
+				version: "12.9",
+			}),
+			Entry("Generic file", "file://sha256:244fd47e07d1004f0aed9c156aa09083c82bf8944eceb67c946ff7430510a77b:foo.jar", &resourceUriComponents{
+				name:    "foo.jar",
+				version: "244fd47e07d1004f0aed9c156aa09083c82bf8944eceb67c946ff7430510a77b",
+			}),
+			Entry("Maven package", "gav://ant:ant:1.6.5", &resourceUriComponents{
+				name:    "ant:ant",
+				version: "1.6.5",
+			}),
+			Entry("npm package", "npm://mocha:2.4.5", &resourceUriComponents{
+				name:    "mocha",
+				version: "2.4.5",
+			}),
+			Entry("scoped npm package", "npm://@babel/core:7.13.14", &resourceUriComponents{
+				name:    "@babel/core",
+				version: "7.13.14",
+			}),
+			Entry("NuGet", "nuget://log4net:9.0.1", &resourceUriComponents{
+				name:    "log4net",
+				version: "9.0.1",
+			}),
+			Entry("pip package", "pip://raven:5.13.0", &resourceUriComponents{
+				name:    "raven",
+				version: "5.13.0",
+			}),
+			Entry("RPM package", "rpm://el6:i386:ImageMagick:6.7.2.7-4", &resourceUriComponents{
+				name:    "ImageMagick",
+				version: "6.7.2.7-4",
+			}),
+			Entry("RPM without a specified distribution", "rpm://el6:i386:ImageMagick:6.7.2.7-4", &resourceUriComponents{
+				name:    "ImageMagick",
+				version: "6.7.2.7-4",
+			}),
+			Entry("Git repository (GitHub)", "git://github.com/rode/rode@bca0e1b89be42a61131b6de09fd2836e7b00c252", &resourceUriComponents{
+				name:    "github.com/rode/rode",
+				version: "bca0e1b89be42a61131b6de09fd2836e7b00c252",
+			}),
+			Entry("Git repository (Azure DevOps)", "git://dev.azure.com/rode/rode/_git/rode@bca0e1b89be42a61131b6de09fd2836e7b00c252", &resourceUriComponents{
+				name:    "dev.azure.com/rode/rode/_git/rode",
+				version: "bca0e1b89be42a61131b6de09fd2836e7b00c252",
+			}),
+		)
+
+		Describe("invalid resource uris", func() {
+			When("a resource uri contains an unexpected type", func() {
+				It("should return an error", func() {
+					invalidUri := "foo://bar"
+					actual, err := parseResourceUri(invalidUri)
+
+					Expect(actual).To(BeNil())
+					Expect(err).To(MatchError("unable to determine resource type for uri: " + invalidUri))
+				})
+			})
+		})
+	})
+})


### PR DESCRIPTION
- handle resource URIs for multiple types of resources
- filtering and sorting on the resource name

To enable sorting, it was necessary to specify some of the mappings for the index up front. I brought over the baseline schema that we use in `grafeas-elasticsearch`, although until we extract some of the migration work there's still the issue of #36 which applies here. 

The schema change did affect the policy endpoints -- it's no longer necessary to specify the `keyword` suffix when searching by id since the field is now indexed as a keyword instead of the default text. I tried to test that out as best I could, but it's possible I affected something there.  