### PR TITLE
Update to validation to check that "violations" blocks return a result object with (id,name,message,pass)

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -25,7 +25,7 @@ import (
 	"github.com/elastic/go-elasticsearch/v7"
 	"github.com/elastic/go-elasticsearch/v7/esapi"
 	"github.com/gogo/protobuf/protoc-gen-gogo/generator"
-	"github.com/hashicorp/hcl/hcl/strconv"
+	"strconv"
 
 	"github.com/google/uuid"
 	"github.com/rode/grafeas-elasticsearch/go/v1beta1/storage/esutil"

--- a/server/server.go
+++ b/server/server.go
@@ -27,7 +27,6 @@ import (
 	"github.com/elastic/go-elasticsearch/v7/esapi"
 	"github.com/gogo/protobuf/protoc-gen-gogo/generator"
 
-	//"github.com/google/martian/v3/body"
 	"github.com/google/uuid"
 	"github.com/rode/grafeas-elasticsearch/go/v1beta1/storage/esutil"
 	"github.com/rode/grafeas-elasticsearch/go/v1beta1/storage/filtering"

--- a/server/server.go
+++ b/server/server.go
@@ -22,10 +22,11 @@ import (
 	"fmt"
 	"net/http"
 
+	"strconv"
+
 	"github.com/elastic/go-elasticsearch/v7"
 	"github.com/elastic/go-elasticsearch/v7/esapi"
 	"github.com/gogo/protobuf/protoc-gen-gogo/generator"
-	"strconv"
 
 	"github.com/google/uuid"
 	"github.com/rode/grafeas-elasticsearch/go/v1beta1/storage/esutil"

--- a/server/server.go
+++ b/server/server.go
@@ -747,7 +747,7 @@ func validateRodeRequirementsForPolicy(mod *ast.Module, regoContent string) []er
 	// policy must contains a violations block somewhere in the code
 	violationsBlockExists := false
 	// missing field from result return response
-	returnFieldsExist := true
+	returnFieldsExist := false
 
 	for _, r := range mod.Rules {
 		if r.Head.Name == "pass" {
@@ -756,20 +756,21 @@ func validateRodeRequirementsForPolicy(mod *ast.Module, regoContent string) []er
 
 		if r.Head.Name == "violations" && r.Head.Key != nil && r.Head.Key.Value.String() == "result" {
 			violationsBlockExists = true
-			for _, module := range r.Module.Rules {
-				fmt.Println(module.Head.Name)
+			for i, module := range r.Module.Rules {
 				if module.Head.Name == "violations" {
 					// get the last body element in the violations block as it must be the result
-
 					terms := module.Body[len(module.Body)-1].Terms.([]*ast.Term)
 					if terms[1].Value.String() == "result" {
 						resultObject := terms[2].Value.String()
-						if !(strings.Contains(resultObject, "\"id\"") && strings.Contains(resultObject, "\"message\"") && strings.Contains(resultObject, "\"name\"") && strings.Contains(resultObject, "\"pass\"")) {
+						// basic string search of the object struct
+						if !(strings.Contains(resultObject, "\"id\":") && strings.Contains(resultObject, "\"message\":") && strings.Contains(resultObject, "\"name\":") && strings.Contains(resultObject, "\"pass\":")) {
 							returnFieldsExist = false
 							break
 						}
 					}
-
+				}
+				if i == (len(r.Module.Rules) - 1) {
+					returnFieldsExist = true
 				}
 			}
 
@@ -785,7 +786,7 @@ func validateRodeRequirementsForPolicy(mod *ast.Module, regoContent string) []er
 		errorsList = append(errorsList, err)
 	}
 	if !returnFieldsExist {
-		err := errors.New("all \"violations\" blocks must return a \"result\" that returns a pass, id, message, and name")
+		err := errors.New("all \"violations\" blocks must return a \"result\" that contains pass, id, message, and name fields")
 		errorsList = append(errorsList, err)
 	}
 

--- a/server/server.go
+++ b/server/server.go
@@ -765,15 +765,21 @@ violationsLoop:
 					if ok {
 						// look at the previous terms to check that it was assigned to result
 						if terms[i-1].String() == "result" {
-							keys := make([]string, len(object.Keys()))
-							for i, key := range object.Keys() {
-								var err error
-								keys[i], err = strconv.Unquote(key.Value.String())
+							keyMap := make(map[string]interface{})
+							for _, key := range object.Keys() {
+								keyVal, err := strconv.Unquote(key.Value.String())
 								if err != nil {
-									keys[i] = key.Value.String()
+									keyVal = key.Value.String()
 								}
+								keyMap[keyVal] = object.Get(key)
 							}
-							if !contains(keys, "pass") || !contains(keys, "name") || !contains(keys, "id") || !contains(keys, "message") {
+
+							_, passExists := keyMap["pass"]
+							_, nameExists := keyMap["name"]
+							_, idExists := keyMap["id"]
+							_, messageExists := keyMap["message"]
+
+							if !passExists || !nameExists || !idExists || !messageExists {
 								break violationsLoop
 							}
 						}

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -105,6 +105,20 @@ var _ = Describe("rode server", func() {
 			m := input.message
 			m == "world"
 		}`
+		compilablePolicyMissingResultsFields = `
+		package harborfail
+		pass = true {
+				3 == 3
+		}
+
+		violations[result] {
+			result = {
+				"pass": true,
+				"name": "Occurrences containing note names",
+				"description": "Verify that all occurrences contain a note name",
+				"message": sprintf("found %v occurrences with missing note names", ["hi"]),
+			}
+		}`
 		unparseablePolicy = `
 		package play
 		default hello = false
@@ -1870,6 +1884,23 @@ var _ = Describe("rode server", func() {
 
 			BeforeEach(func() {
 				policyEntity = createRandomPolicyEntity(compilablePolicyMissingRodeFields)
+				policyResponse, err = rodeServer.CreatePolicy(context.Background(), policyEntity)
+			})
+
+			It("should throw a compilation error", func() {
+				Expect(policyResponse).To(BeNil())
+				Expect(err).To(HaveOccurred())
+			})
+		})
+		When("creating an compilable policy with missing required fields in the result object", func() {
+			var (
+				policyEntity   *pb.PolicyEntity
+				policyResponse *pb.Policy
+				err            error
+			)
+
+			BeforeEach(func() {
+				policyEntity = createRandomPolicyEntity(compilablePolicyMissingResultsFields)
 				policyResponse, err = rodeServer.CreatePolicy(context.Background(), policyEntity)
 			})
 

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -112,7 +112,21 @@ var _ = Describe("rode server", func() {
 		}
 
 		violations[result] {
-			result = {
+			result := {
+				"pass": true,
+				"name": "Occurrences containing note names",
+				"description": "Verify that all occurrences contain a note name",
+				"message": sprintf("found %v occurrences with missing note names", ["hi"]),
+			}
+		}`
+		compilablePolicyMissingResultsReturn = `
+		package harborfail
+		pass = true {
+				3 == 3
+		}
+
+		violations {
+			a := {
 				"pass": true,
 				"name": "Occurrences containing note names",
 				"description": "Verify that all occurrences contain a note name",
@@ -1884,6 +1898,23 @@ var _ = Describe("rode server", func() {
 
 			BeforeEach(func() {
 				policyEntity = createRandomPolicyEntity(compilablePolicyMissingRodeFields)
+				policyResponse, err = rodeServer.CreatePolicy(context.Background(), policyEntity)
+			})
+
+			It("should throw a compilation error", func() {
+				Expect(policyResponse).To(BeNil())
+				Expect(err).To(HaveOccurred())
+			})
+		})
+		When("creating an compilable policy with missing results return", func() {
+			var (
+				policyEntity   *pb.PolicyEntity
+				policyResponse *pb.Policy
+				err            error
+			)
+
+			BeforeEach(func() {
+				policyEntity = createRandomPolicyEntity(compilablePolicyMissingResultsReturn)
 				policyResponse, err = rodeServer.CreatePolicy(context.Background(), policyEntity)
 			})
 


### PR DESCRIPTION
The overall approach should be revisited, but this currently works as expected.
The AST is parsed until the final element of the "violations" block which should be the return value. The object is received as a string and checked for those fields.

I can create a ticket for a bit more of a deep dive around how to walk this AST