### PR TITLE
Last page token on paginated requests should be an empty string

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -51,7 +51,7 @@ const (
 	rodeElasticsearchPoliciesIndex         = "rode-v1alpha1-policies"
 	rodeElasticsearchGenericResourcesIndex = "rode-v1alpha1-generic-resources"
 	maxPageSize                            = 1000
-	pitKeepAlive                           = "1m"
+	pitKeepAlive                           = "5m"
 )
 
 // NewRodeServer constructor for rodeServer

--- a/server/server.go
+++ b/server/server.go
@@ -865,6 +865,16 @@ func (r *rodeServer) genericList(ctx context.Context, log *zap.Logger, options *
 		return nil, "", createError(log, "error decoding elasticsearch response", err)
 	}
 
+	if options.pageToken != "" || options.pageSize != 0 { // if request is paginated, check for last page
+		_, from, err := esutil.ParsePageToken(nextPageToken)
+		if err != nil {
+			return nil, "", createError(log, "error parsing page token", err)
+		}
+
+		if from >= searchResults.Hits.Total.Value {
+			nextPageToken = ""
+		}
+	}
 	return searchResults.Hits, nextPageToken, nil
 }
 

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -1776,7 +1776,7 @@ var _ = Describe("rode server", func() {
 								Id:     gofakeit.UUID(),
 								Policy: createRandomPolicyEntity(goodPolicy),
 							},
-						}, gofakeit.Number(1, int(expectedPageSize) + expectedFrom - 1))
+						}, gofakeit.Number(1, int(expectedPageSize)+expectedFrom-1))
 					})
 
 					It("should return an empty next page token", func() {

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -886,7 +886,7 @@ var _ = Describe("rode server", func() {
 						It("should create a PIT in Elasticsearch", func() {
 							Expect(esTransport.receivedHttpRequests[2].URL.Path).To(Equal(fmt.Sprintf("/%s/_pit", rodeElasticsearchGenericResourcesIndex)))
 							Expect(esTransport.receivedHttpRequests[2].Method).To(Equal(http.MethodPost))
-							Expect(esTransport.receivedHttpRequests[2].URL.Query().Get("keep_alive")).To(Equal("1m"))
+							Expect(esTransport.receivedHttpRequests[2].URL.Query().Get("keep_alive")).To(Equal("5m"))
 						})
 
 						It("should query using the PIT", func() {
@@ -894,7 +894,7 @@ var _ = Describe("rode server", func() {
 							Expect(esTransport.receivedHttpRequests[3].Method).To(Equal(http.MethodGet))
 							request := readEsSearchResponse(esTransport.receivedHttpRequests[3])
 							Expect(request.Pit.Id).To(Equal(expectedPitId))
-							Expect(request.Pit.KeepAlive).To(Equal("1m"))
+							Expect(request.Pit.KeepAlive).To(Equal("5m"))
 						})
 
 						It("should not return an error", func() {
@@ -922,7 +922,7 @@ var _ = Describe("rode server", func() {
 							Expect(esTransport.receivedHttpRequests[2].Method).To(Equal(http.MethodGet))
 							request := readEsSearchResponse(esTransport.receivedHttpRequests[2])
 							Expect(request.Pit.Id).To(Equal(expectedPitId))
-							Expect(request.Pit.KeepAlive).To(Equal("1m"))
+							Expect(request.Pit.KeepAlive).To(Equal("5m"))
 						})
 
 						It("should return the next page token", func() {
@@ -1413,7 +1413,7 @@ var _ = Describe("rode server", func() {
 					It("should create a PIT in Elasticsearch", func() {
 						Expect(esTransport.receivedHttpRequests[2].URL.Path).To(Equal(fmt.Sprintf("/%s/_pit", rodeElasticsearchOccurrencesAlias)))
 						Expect(esTransport.receivedHttpRequests[2].Method).To(Equal(http.MethodPost))
-						Expect(esTransport.receivedHttpRequests[2].URL.Query().Get("keep_alive")).To(Equal("1m"))
+						Expect(esTransport.receivedHttpRequests[2].URL.Query().Get("keep_alive")).To(Equal("5m"))
 					})
 
 					It("should query using the PIT", func() {
@@ -1421,7 +1421,7 @@ var _ = Describe("rode server", func() {
 						Expect(esTransport.receivedHttpRequests[3].Method).To(Equal(http.MethodGet))
 						request := readEsSearchResponse(esTransport.receivedHttpRequests[3])
 						Expect(request.Pit.Id).To(Equal(expectedPitId))
-						Expect(request.Pit.KeepAlive).To(Equal("1m"))
+						Expect(request.Pit.KeepAlive).To(Equal("5m"))
 					})
 
 					It("should not return an error", func() {
@@ -1449,7 +1449,7 @@ var _ = Describe("rode server", func() {
 						Expect(esTransport.receivedHttpRequests[2].Method).To(Equal(http.MethodGet))
 						request := readEsSearchResponse(esTransport.receivedHttpRequests[2])
 						Expect(request.Pit.Id).To(Equal(expectedPitId))
-						Expect(request.Pit.KeepAlive).To(Equal("1m"))
+						Expect(request.Pit.KeepAlive).To(Equal("5m"))
 					})
 
 					It("should return the next page token", func() {
@@ -1722,7 +1722,7 @@ var _ = Describe("rode server", func() {
 				It("should create a PIT in Elasticsearch", func() {
 					Expect(esTransport.receivedHttpRequests[2].URL.Path).To(Equal(fmt.Sprintf("/%s/_pit", rodeElasticsearchPoliciesIndex)))
 					Expect(esTransport.receivedHttpRequests[2].Method).To(Equal(http.MethodPost))
-					Expect(esTransport.receivedHttpRequests[2].URL.Query().Get("keep_alive")).To(Equal("1m"))
+					Expect(esTransport.receivedHttpRequests[2].URL.Query().Get("keep_alive")).To(Equal("5m"))
 				})
 
 				It("should query using the PIT", func() {
@@ -1730,7 +1730,7 @@ var _ = Describe("rode server", func() {
 					Expect(esTransport.receivedHttpRequests[3].Method).To(Equal(http.MethodGet))
 					request := readEsSearchResponse(esTransport.receivedHttpRequests[3])
 					Expect(request.Pit.Id).To(Equal(expectedPitId))
-					Expect(request.Pit.KeepAlive).To(Equal("1m"))
+					Expect(request.Pit.KeepAlive).To(Equal("5m"))
 				})
 
 				It("should not return an error", func() {
@@ -1758,7 +1758,7 @@ var _ = Describe("rode server", func() {
 					Expect(esTransport.receivedHttpRequests[2].Method).To(Equal(http.MethodGet))
 					request := readEsSearchResponse(esTransport.receivedHttpRequests[2])
 					Expect(request.Pit.Id).To(Equal(expectedPitId))
-					Expect(request.Pit.KeepAlive).To(Equal("1m"))
+					Expect(request.Pit.KeepAlive).To(Equal("5m"))
 				})
 
 				It("should return the next page token", func() {

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -862,9 +862,9 @@ var _ = Describe("rode server", func() {
 					)
 
 					BeforeEach(func() {
-						expectedPageSize = int32(gofakeit.Number(10, 100))
+						expectedPageSize = int32(gofakeit.Number(1, len(genericResources) - 1))
 						expectedPitId = gofakeit.LetterN(20)
-						expectedFrom = gofakeit.Number(10, 100)
+						expectedFrom = gofakeit.Number(0, 1)
 
 						listRequest.PageSize = expectedPageSize
 					})
@@ -1383,9 +1383,9 @@ var _ = Describe("rode server", func() {
 				)
 
 				BeforeEach(func() {
-					expectedPageSize = int32(gofakeit.Number(10, 100))
+					expectedPageSize = int32(gofakeit.Number(1, len(occurrences) - 1))
 					expectedPitId = gofakeit.LetterN(20)
-					expectedFrom = gofakeit.Number(10, 100)
+					expectedFrom = gofakeit.Number(0, 1)
 
 					request.PageSize = expectedPageSize
 				})
@@ -2162,6 +2162,9 @@ func createEsSearchResponseForGenericResource(resources []*pb.GenericResource) i
 	response := &esutil.EsSearchResponse{
 		Hits: &esutil.EsSearchResponseHits{
 			Hits: hits,
+			Total: &esutil.EsSearchResponseTotal{
+				Value: len(resources),
+			},
 		},
 		Took: gofakeit.Number(1, 10),
 	}


### PR DESCRIPTION
Related to [this PR in grafeas-elasticsearch](https://github.com/rode/grafeas-elasticsearch/pull/72)