### PR TITLE
Fix chart-promote job

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -48,13 +48,13 @@ jobs:
         uses: liatrio/github-actions/gitops-semver-increment-yaml@master
         with:
           file: charts/rode/Chart.yaml
-          path: version
+          path: .version
           position: PATCH
       - name: Update application version
         uses: liatrio/github-actions/gitops-update-yaml@master
         with:
           file: charts/rode/Chart.yaml
-          path: appVersion
+          path: .appVersion
           value: ${{ steps.tag.outputs.TAG }}
       - name: Create pull request
         uses: liatrio/github-actions/gitops-gh-pr@master


### PR DESCRIPTION
The past two releases have failed during the `chart-promote` job with the following:
>Error: Parsing expression: Lexer error: could not match text starting at 1:1 failing at 1:2.
	unmatched text: "v"

This is due to a difference in `yq` v3 versus v4, which was upgraded while working on the action. 

Here's a sample build [log](https://github.com/rode/rode/runs/2605253981?check_suite_focus=true#step:7:7). The [rode-ui version of the job](https://github.com/rode/rode-ui/blob/aee2d3f7aed8a37e25730669f22351b465a1c1ea/.github/workflows/publish.yaml#L75-L86) has the same selectors and it ran successfully during the demo. 