### PR TITLE
Specify sort order for ListPolicies

### DIFF
--- a/pkg/policy/manager.go
+++ b/pkg/policy/manager.go
@@ -278,6 +278,9 @@ func (m *manager) ListPolicies(ctx context.Context, request *pb.ListPoliciesRequ
 					Must: &queries,
 				},
 			},
+			Sort: map[string]esutil.EsSortOrder{
+				"created": esutil.EsSortOrderDescending,
+			},
 		},
 	}
 

--- a/pkg/policy/manager_test.go
+++ b/pkg/policy/manager_test.go
@@ -635,6 +635,7 @@ var _ = Describe("PolicyManager", func() {
 
 			Expect(actualRequest.Index).To(Equal(expectedPoliciesAlias))
 			Expect(actualRequest.Pagination).To(BeNil())
+			Expect(actualRequest.Search.Sort["created"]).To(Equal(esutil.EsSortOrderDescending))
 			Expect(*actualRequest.Search.Query.Bool.Must).To(HaveLen(2))
 
 			actualJoinQuery := (*actualRequest.Search.Query.Bool.Must)[0].(*filtering.Query)


### PR DESCRIPTION
This was the sort order prior to #87, but I missed that when converting over to use `esutil.Client` as part of the versioning changes. 