### PR TITLE
fix: ListResourceEvaluations should return an empty list when no evaluations are found

### DIFF
--- a/pkg/evaluation/manager.go
+++ b/pkg/evaluation/manager.go
@@ -330,6 +330,10 @@ func (m *manager) ListResourceEvaluations(ctx context.Context, request *pb.ListR
 		return nil, util.GrpcInternalError(log, "error searching for resource evaluations", err)
 	}
 
+	if searchResponse.Hits.Total.Value == 0 {
+		return &pb.ListResourceEvaluationsResponse{}, nil
+	}
+
 	var (
 		resourceEvaluationResults []*pb.ResourceEvaluationResult
 		policyEvaluationSearches  []*esutil.EsSearch

--- a/pkg/evaluation/manager_test.go
+++ b/pkg/evaluation/manager_test.go
@@ -862,6 +862,22 @@ var _ = Describe("evaluation manager", func() {
 				Expect(esClient.SearchCallCount()).To(Equal(0))
 			})
 		})
+
+		When("no resource evaluations are found", func() {
+			BeforeEach(func() {
+				expectedSearchResponse.Hits.Total.Value = 0
+				expectedSearchResponse.Hits.Hits = []*esutil.EsSearchResponseHit{}
+			})
+
+			It("should not perform a multisearch", func() {
+				Expect(esClient.MultiSearchCallCount()).To(BeZero())
+			})
+
+			It("should return a response with an empty list", func() {
+				Expect(actualListResourceEvaluationsResponse.ResourceEvaluations).To(BeEmpty())
+				Expect(actualError).ToNot(HaveOccurred())
+			})
+		})
 	})
 
 	Context("GetResourceEvaluation", func() {


### PR DESCRIPTION
Fixes #125 