### PR TITLE
Don't build binaries for 386 arch

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -11,6 +11,11 @@ builds:
       - linux
       - windows
       - darwin
+    goarch:
+      - amd64
+      - arm
+      - arm64
+
 archives:
 checksum:
   name_template: 'checksums.txt'


### PR DESCRIPTION
Tried to cut a release after #123 was merged, but ran into an [error in the workflow](https://github.com/rode/rode/runs/3011917502):

```
   ⨯ release failed after 299.18s error=failed to build for linux_386: # github.com/scylladb/go-set/strset
Error: ../../../go/pkg/mod/github.com/scylladb/go-set@v1.0.2/strset/strset.go:248:10: constant 9223372036854775807 overflows int
Error: ../../../go/pkg/mod/github.com/scylladb/go-set@v1.0.2/strset/strset.go:255:13: constant 9223372036854775807 overflows int

Error: The process '/opt/hostedtoolcache/goreleaser-action/0.173.2/x64/goreleaser' failed with exit code 1
```

One of the dependencies added in #123 uses `math.MaxInt64` which fails to compile when targeting a 32bit arch.
There's a fix in the master branch, but no tag. We could pin it to the commit, but I doubt there will ever be any reason to use the 32bit builds. 

```
https://github.com/scylladb/go-set/commit/cc7b2070d91ebf40d233207b633e28f5bd8f03a5
https://github.com/scylladb/go-set/issues/16
```

This will also added ARM6 builds for Linux and Windows, but we can drop those if desired. 