### PR TITLE
fix: add additional checks to see if auth config is configured

### DIFF
--- a/common/client.go
+++ b/common/client.go
@@ -36,7 +36,7 @@ func NewRodeClient(config *ClientConfig) (pb.RodeClient, error) {
 		return nil, errors.New("rode host must be specified")
 	}
 
-	if config.OIDCAuth != nil && config.BasicAuth != nil {
+	if config.oidcAuthIsConfigured() && config.basicAuthIsConfigured() {
 		return nil, errors.New("only one authentication method can be used")
 	}
 
@@ -46,7 +46,7 @@ func NewRodeClient(config *ClientConfig) (pb.RodeClient, error) {
 		dialOptions = append(dialOptions, grpc.WithInsecure())
 	}
 
-	if config.OIDCAuth != nil {
+	if config.oidcAuthIsConfigured() {
 		oidcCredentials, err := newOidcAuth(config.OIDCAuth, config.Rode.DisableTransportSecurity)
 		if err != nil {
 			return nil, fmt.Errorf("error configuring OIDC auth: %v", err)
@@ -55,7 +55,7 @@ func NewRodeClient(config *ClientConfig) (pb.RodeClient, error) {
 		dialOptions = append(dialOptions, grpc.WithPerRPCCredentials(oidcCredentials))
 	}
 
-	if config.BasicAuth != nil {
+	if config.basicAuthIsConfigured() {
 		if config.BasicAuth.Username == "" || config.BasicAuth.Password == "" {
 			return nil, errors.New("both username and password must be set for basic auth")
 		}

--- a/common/client_basic_auth.go
+++ b/common/client_basic_auth.go
@@ -46,3 +46,7 @@ func (b basicAuth) GetRequestMetadata(context.Context, ...string) (map[string]st
 func (b basicAuth) RequireTransportSecurity() bool {
 	return !b.insecure
 }
+
+func (c *ClientConfig) basicAuthIsConfigured() bool {
+	return c.BasicAuth != nil && (c.BasicAuth.Username != "" || c.BasicAuth.Password != "")
+}

--- a/common/client_oidc_auth.go
+++ b/common/client_oidc_auth.go
@@ -83,3 +83,7 @@ func (j oidcAuth) GetRequestMetadata(context.Context, ...string) (map[string]str
 func (j oidcAuth) RequireTransportSecurity() bool {
 	return !j.insecure
 }
+
+func (c *ClientConfig) oidcAuthIsConfigured() bool {
+	return c.OIDCAuth != nil && (c.OIDCAuth.ClientID != "" || c.OIDCAuth.ClientSecret != "")
+}

--- a/common/client_test.go
+++ b/common/client_test.go
@@ -83,7 +83,9 @@ var _ = Describe("client", func() {
 	})
 
 	JustBeforeEach(func() {
-		go fakeServer.Serve(fakeListener)
+		go func() {
+			_ = fakeServer.Serve(fakeListener)
+		}()
 		actualRodeClient, actualError = NewRodeClient(expectedConfig)
 	})
 
@@ -132,8 +134,12 @@ var _ = Describe("client", func() {
 
 	When("more than one authentication method is specified", func() {
 		BeforeEach(func() {
-			expectedConfig.BasicAuth = &BasicAuthConfig{}
-			expectedConfig.OIDCAuth = &OIDCAuthConfig{}
+			expectedConfig.BasicAuth = &BasicAuthConfig{
+				Username: fake.Username(),
+			}
+			expectedConfig.OIDCAuth = &OIDCAuthConfig{
+				ClientID: fake.UUID(),
+			}
 		})
 
 		It("should return an error", func() {


### PR DESCRIPTION
each auth config has to be non-nil due to the way the `flag` package sets properties for these structs, so just checking that they aren't nil isn't enough to determine whether or not basic / oidc auth is configured.