### PR TITLE
Expose TlsInsecureSkipVerify setting for oidc config

### DIFF
--- a/common/client_flags.go
+++ b/common/client_flags.go
@@ -29,6 +29,7 @@ func SetupRodeClientFlags(flags *flag.FlagSet) *ClientConfig {
 	flags.StringVar(&conf.OIDCAuth.ClientID, "oidc-client-id", "", "the client ID to use when requesting a JWT via the client_credentials OIDC grant")
 	flags.StringVar(&conf.OIDCAuth.ClientSecret, "oidc-client-secret", "", "the client secret to use when requesting a JWT via the client_credentials OIDC grant")
 	flags.StringVar(&conf.OIDCAuth.TokenURL, "oidc-token-url", "", "the URL to use to retrieve an access token via the client_credentials OIDC grant")
+	flags.BoolVar(&conf.OIDCAuth.TlsInsecureSkipVerify, "oidc-tls-insecure-skip-verify", false, "when set, TLS connections to the token url won't be verified")
 
 	flags.StringVar(&conf.BasicAuth.Username, "basic-auth-username", "", "the username to use for basic authentication")
 	flags.StringVar(&conf.BasicAuth.Password, "basic-auth-password", "", "the password to use for basic authentication")

--- a/common/client_flags_test.go
+++ b/common/client_flags_test.go
@@ -84,9 +84,9 @@ var _ = Describe("client flags", func() {
 				Host: "rode:50051",
 			},
 			OIDCAuth: &OIDCAuthConfig{
-				ClientID:     expectedClientId,
-				ClientSecret: expectedClientSecret,
-				TokenURL:     expectedTokenUrl,
+				ClientID:              expectedClientId,
+				ClientSecret:          expectedClientSecret,
+				TokenURL:              expectedTokenUrl,
 				TlsInsecureSkipVerify: true,
 			},
 			BasicAuth: &BasicAuthConfig{},

--- a/common/client_flags_test.go
+++ b/common/client_flags_test.go
@@ -78,6 +78,7 @@ var _ = Describe("client flags", func() {
 			"--oidc-client-id=" + expectedClientId,
 			"--oidc-client-secret=" + expectedClientSecret,
 			"--oidc-token-url=" + expectedTokenUrl,
+			"--oidc-tls-insecure-skip-verify",
 		}, &ClientConfig{
 			Rode: &RodeClientConfig{
 				Host: "rode:50051",
@@ -86,6 +87,7 @@ var _ = Describe("client flags", func() {
 				ClientID:     expectedClientId,
 				ClientSecret: expectedClientSecret,
 				TokenURL:     expectedTokenUrl,
+				TlsInsecureSkipVerify: true,
 			},
 			BasicAuth: &BasicAuthConfig{},
 		}),


### PR DESCRIPTION
I was testing out https://github.com/rode/collector-sonarqube/pull/17 and wasn't able to start the collector using the oidc flags against a self-signed certificate. 