### PR TITLE
Changes for Azure AD integration

### DIFF
--- a/auth/role_registry.go
+++ b/auth/role_registry.go
@@ -20,9 +20,9 @@ var (
 	RoleAnonymous            Role = "Anonymous"
 	RoleEnforcer             Role = "Enforcer"
 	RoleCollector            Role = "Collector"
-	RoleApplicationDeveloper Role = "Application Developer"
-	RolePolicyDeveloper      Role = "Policy Developer"
-	RolePolicyAdministrator  Role = "Policy Administrator"
+	RoleApplicationDeveloper Role = "ApplicationDeveloper"
+	RolePolicyDeveloper      Role = "PolicyDeveloper"
+	RolePolicyAdministrator  Role = "PolicyAdministrator"
 	RoleAdministrator        Role = "Administrator"
 
 	PermissionCollectorRegister      Permission = "rode.collector.register"

--- a/auth/role_registry_test.go
+++ b/auth/role_registry_test.go
@@ -33,9 +33,9 @@ var _ = Describe("RoleRegistry", func() {
 			Entry("Anonymous", "Anonymous", RoleAnonymous),
 			Entry("Enforcer", "Enforcer", RoleEnforcer),
 			Entry("Collector", "Collector", RoleCollector),
-			Entry("Application Developer", "Application Developer", RoleApplicationDeveloper),
-			Entry("Policy Developer", "Policy Developer", RolePolicyDeveloper),
-			Entry("Policy Administrator", "Policy Administrator", RolePolicyAdministrator),
+			Entry("Application Developer", "ApplicationDeveloper", RoleApplicationDeveloper),
+			Entry("Policy Developer", "PolicyDeveloper", RolePolicyDeveloper),
+			Entry("Policy Administrator", "PolicyAdministrator", RolePolicyAdministrator),
 			Entry("Administrator", "Administrator", RoleAdministrator),
 		)
 

--- a/common/client_flags.go
+++ b/common/client_flags.go
@@ -30,6 +30,7 @@ func SetupRodeClientFlags(flags *flag.FlagSet) *ClientConfig {
 	flags.StringVar(&conf.OIDCAuth.ClientSecret, "oidc-client-secret", "", "the client secret to use when requesting a JWT via the client_credentials OIDC grant")
 	flags.StringVar(&conf.OIDCAuth.TokenURL, "oidc-token-url", "", "the URL to use to retrieve an access token via the client_credentials OIDC grant")
 	flags.BoolVar(&conf.OIDCAuth.TlsInsecureSkipVerify, "oidc-tls-insecure-skip-verify", false, "when set, TLS connections to the token url won't be verified")
+	flags.StringVar(&conf.OIDCAuth.Scopes, "oidc-scopes", "", "a space delimited set of scopes to request")
 
 	flags.StringVar(&conf.BasicAuth.Username, "basic-auth-username", "", "the username to use for basic authentication")
 	flags.StringVar(&conf.BasicAuth.Password, "basic-auth-password", "", "the password to use for basic authentication")

--- a/common/client_flags_test.go
+++ b/common/client_flags_test.go
@@ -16,6 +16,8 @@ package common
 
 import (
 	"flag"
+	"strings"
+
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/ginkgo/extensions/table"
 	. "github.com/onsi/gomega"
@@ -29,6 +31,7 @@ var _ = Describe("client flags", func() {
 		expectedClientId     string
 		expectedClientSecret string
 		expectedTokenUrl     string
+		expectedScopes       string
 
 		expectedUsername string
 		expectedPassword string
@@ -42,6 +45,7 @@ var _ = Describe("client flags", func() {
 		expectedClientId = fake.LetterN(10)
 		expectedClientSecret = fake.UUID()
 		expectedTokenUrl = fake.URL()
+		expectedScopes = strings.Join([]string{fake.LetterN(10), fake.LetterN(10)}, " ")
 
 		expectedUsername = fake.LetterN(10)
 		expectedPassword = fake.LetterN(10)
@@ -79,6 +83,7 @@ var _ = Describe("client flags", func() {
 			"--oidc-client-secret=" + expectedClientSecret,
 			"--oidc-token-url=" + expectedTokenUrl,
 			"--oidc-tls-insecure-skip-verify",
+			"--oidc-scopes=" + expectedScopes,
 		}, &ClientConfig{
 			Rode: &RodeClientConfig{
 				Host: "rode:50051",
@@ -86,6 +91,7 @@ var _ = Describe("client flags", func() {
 			OIDCAuth: &OIDCAuthConfig{
 				ClientID:              expectedClientId,
 				ClientSecret:          expectedClientSecret,
+				Scopes:                expectedScopes,
 				TokenURL:              expectedTokenUrl,
 				TlsInsecureSkipVerify: true,
 			},

--- a/common/client_oidc_auth.go
+++ b/common/client_oidc_auth.go
@@ -23,6 +23,7 @@ import (
 	"golang.org/x/oauth2/clientcredentials"
 	"google.golang.org/grpc/credentials"
 	"net/http"
+	"strings"
 )
 
 type oidcAuth struct {
@@ -47,6 +48,10 @@ func newOidcAuth(config *OIDCAuthConfig, insecure bool) (credentials.PerRPCCrede
 		ClientID:     config.ClientID,
 		ClientSecret: config.ClientSecret,
 		TokenURL:     config.TokenURL,
+	}
+
+	if config.Scopes != "" {
+		clientCredentialsConfig.Scopes = strings.Split(strings.TrimSpace(config.Scopes), " ")
 	}
 
 	ctx := context.Background()

--- a/common/types.go
+++ b/common/types.go
@@ -30,6 +30,7 @@ type OIDCAuthConfig struct {
 	ClientSecret          string
 	TokenURL              string
 	TlsInsecureSkipVerify bool
+	Scopes                string
 }
 
 type BasicAuthConfig struct {


### PR DESCRIPTION
- app role values in AzureAD cannot contain spaces (although they can apparently be empty)
- for the collectors and enforcers to use the client credentials flow, they must pass a scope of `${RODE_CLIENT_ID}./default`, so I've added an option to include scopes in the oauth2 configuration

For the role values, I updated the Keycloak demo Terraform: https://github.com/rode/demo/pull/68