### PR TITLE
Allow enforcers to read policies

### DIFF
--- a/auth/role_registry.go
+++ b/auth/role_registry.go
@@ -68,6 +68,7 @@ func NewRoleRegistry() RoleRegistry {
 			RoleEnforcer: {
 				PermissionEvaluationResultRead,
 				PermissionPolicyGroupRead,
+				PermissionPolicyRead,
 				PermissionResourceEvaluate,
 				PermissionResourceRead,
 			},


### PR DESCRIPTION
Ran into this testing https://github.com/rode/evaluate-policy-action/pull/6. Both the action and `enforcer-k8s` fetch the policy names to render more useful output, but only had read for policy groups. 