### PR TITLE
Bump es-index-manager 

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -25,7 +25,7 @@ require (
 	github.com/peterbourgon/ff/v3 v3.1.0
 	github.com/pquerna/cachecontrol v0.1.0 // indirect
 	github.com/rcrowley/go-metrics v0.0.0-20201227073835-cf1acfcdf475 // indirect
-	github.com/rode/es-index-manager v0.1.2
+	github.com/rode/es-index-manager v0.2.2
 	github.com/rode/grafeas-elasticsearch v0.8.7
 	github.com/scylladb/go-set v1.0.2
 	github.com/soheilhy/cmux v0.1.4

--- a/go.sum
+++ b/go.sum
@@ -425,8 +425,6 @@ github.com/rcrowley/go-metrics v0.0.0-20200313005456-10cdbea86bc0/go.mod h1:bCqn
 github.com/rcrowley/go-metrics v0.0.0-20201227073835-cf1acfcdf475 h1:N/ElC8H3+5XpJzTSTfLsJV/mx9Q9g7kxmchpfZyxgzM=
 github.com/rcrowley/go-metrics v0.0.0-20201227073835-cf1acfcdf475/go.mod h1:bCqnVzQkZxMG4s8nGwiZ5l3QUCyqpo9Y+/ZMZ9VjZe4=
 github.com/rode/es-index-manager v0.1.1/go.mod h1:QsnfBo0VUWWfOkXUHUdiWSiJghajbVwHjCA+OMqO0E8=
-github.com/rode/es-index-manager v0.1.2 h1:cWRRKM5sNO+E/1jiKJXae0h3KsaTXgdbAdkDPq3wrno=
-github.com/rode/es-index-manager v0.1.2/go.mod h1:QsnfBo0VUWWfOkXUHUdiWSiJghajbVwHjCA+OMqO0E8=
 github.com/rode/es-index-manager v0.2.2 h1:rhJBE6//OHnH9HIxmukgrrh4NVNm7T4XkC016umX2qM=
 github.com/rode/es-index-manager v0.2.2/go.mod h1:QsnfBo0VUWWfOkXUHUdiWSiJghajbVwHjCA+OMqO0E8=
 github.com/rode/grafeas-elasticsearch v0.8.7 h1:bddnIFcWL84r2rgrAazeaSFdnYzvjKIyM4pPtCrkveI=

--- a/go.sum
+++ b/go.sum
@@ -427,6 +427,8 @@ github.com/rcrowley/go-metrics v0.0.0-20201227073835-cf1acfcdf475/go.mod h1:bCqn
 github.com/rode/es-index-manager v0.1.1/go.mod h1:QsnfBo0VUWWfOkXUHUdiWSiJghajbVwHjCA+OMqO0E8=
 github.com/rode/es-index-manager v0.1.2 h1:cWRRKM5sNO+E/1jiKJXae0h3KsaTXgdbAdkDPq3wrno=
 github.com/rode/es-index-manager v0.1.2/go.mod h1:QsnfBo0VUWWfOkXUHUdiWSiJghajbVwHjCA+OMqO0E8=
+github.com/rode/es-index-manager v0.2.2 h1:rhJBE6//OHnH9HIxmukgrrh4NVNm7T4XkC016umX2qM=
+github.com/rode/es-index-manager v0.2.2/go.mod h1:QsnfBo0VUWWfOkXUHUdiWSiJghajbVwHjCA+OMqO0E8=
 github.com/rode/grafeas-elasticsearch v0.8.7 h1:bddnIFcWL84r2rgrAazeaSFdnYzvjKIyM4pPtCrkveI=
 github.com/rode/grafeas-elasticsearch v0.8.7/go.mod h1:bu4sKOyP7/a/PZdywh5I16P+b8j+8GuaIUIECun6a60=
 github.com/rogpeppe/fastuuid v0.0.0-20150106093220-6724a57986af/go.mod h1:XWv6SoW27p1b0cqNHllgS5HIMJraePCO15w5zCzIWYg=


### PR DESCRIPTION
Brings in https://github.com/rode/es-index-manager/pull/11, so that we don't crash when an index appears to belong to Rode but doesn't have a mapping. 
