### PR TITLE
Fix nil dereference in policy evaluation

### DIFF
--- a/pkg/evaluation/manager.go
+++ b/pkg/evaluation/manager.go
@@ -443,13 +443,18 @@ func (m *manager) EvaluatePolicy(ctx context.Context, request *pb.EvaluatePolicy
 		}
 	}
 
-	return &pb.EvaluatePolicyResponse{
+	response := &pb.EvaluatePolicyResponse{
 		Pass: evaluatePolicyResponse.Result.Pass,
 		Result: []*pb.EvaluatePolicyResult{
 			attestation,
 		},
-		Explanation: *evaluatePolicyResponse.Explanation,
-	}, nil
+	}
+
+	if evaluatePolicyResponse.Explanation != nil {
+		response.Explanation = *evaluatePolicyResponse.Explanation
+	}
+
+	return response, nil
 }
 
 func (m *manager) evaluatePolicy(ctx context.Context, policyId, rego string, occurrences []*grafeas_go_proto.Occurrence) (*opa.EvaluatePolicyResponse, error) {

--- a/pkg/evaluation/manager_test.go
+++ b/pkg/evaluation/manager_test.go
@@ -1249,6 +1249,16 @@ var _ = Describe("evaluation manager", func() {
 				Expect(actualViolations).To(ConsistOf(expectedViolations))
 			})
 		})
+
+		When("the explanation is not present", func() {
+			BeforeEach(func() {
+				opaEvaluatePolicyResponse.Explanation = nil
+			})
+
+			It("should not try to include an explanation in the result", func() {
+				Expect(actualResponse.Explanation).To(BeEmpty())
+			})
+		})
 	})
 })
 


### PR DESCRIPTION
I was looking into some issues with resource usage in Open Policy Agent when Rode runs in debug mode. In debug mode, we request a pretty-printed response and full explanation from OPA. This was causing a large increase in memory in OPA.

With `explain=full` and `pretty` (~7MB -> ~445MB):

![Screen Shot 2021-08-10 at 2 58 20 PM](https://user-images.githubusercontent.com/9082799/128920971-13e2e2ee-ce2a-4472-b642-f7793b52a703.png)

In production/non-debug mode (~7MB -> ~9MB):
![Screen Shot 2021-08-10 at 2 58 13 PM](https://user-images.githubusercontent.com/9082799/128920968-71c5be51-3532-4b23-a441-524000a88a19.png)


In the short term, I think turning off debug mode is the easiest solution for now. Unfortunately, when I tried that out locally, it caused a nil pointer dereference. This PR fixes the nil pointer evaluation so that we can run Rode in production mode.

Long term,  we may want to explore the following:
- upgrading OPA -- we use the 0.27.0 library for parsing policies, but run against the 0.24.0 version in the demo (~10 months old)
- Remove the explanation altogether
- Embed [OPA as a library](https://www.openpolicyagent.org/docs/latest/integration/#integrating-with-the-go-api), instead of calling it as an external service

<details>
<summary>stacktrace</summary>

```
runtime error: invalid memory address or nil pointer dereference
main.main.func1
	rode/rode/main.go:79
github.com/grpc-ecosystem/go-grpc-middleware/recovery.WithRecoveryHandler.func1.1
	/go/pkg/mod/github.com/grpc-ecosystem/go-grpc-middleware@v1.2.2/recovery/options.go:33
github.com/grpc-ecosystem/go-grpc-middleware/recovery.recoverFrom
	/go/pkg/mod/github.com/grpc-ecosystem/go-grpc-middleware@v1.2.2/recovery/interceptors.go:61
github.com/grpc-ecosystem/go-grpc-middleware/recovery.UnaryServerInterceptor.func1.1
	/go/pkg/mod/github.com/grpc-ecosystem/go-grpc-middleware@v1.2.2/recovery/interceptors.go:29
runtime.gopanic
	/usr/local/go/src/runtime/panic.go:965
runtime.panicmem
	/usr/local/go/src/runtime/panic.go:212
runtime.sigpanic
	/usr/local/go/src/runtime/signal_unix.go:734
github.com/rode/rode/pkg/evaluation.(*manager).EvaluatePolicy
	rode/rode/pkg/evaluation/manager.go:451
github.com/rode/rode/proto/v1alpha1._Rode_EvaluatePolicy_Handler.func1
	rode/rode/proto/v1alpha1/rode_grpc.pb.go:512
github.com/grpc-ecosystem/go-grpc-middleware/auth.UnaryServerInterceptor.func1
	/go/pkg/mod/github.com/grpc-ecosystem/go-grpc-middleware@v1.2.2/auth/auth.go:47
github.com/grpc-ecosystem/go-grpc-middleware.ChainUnaryServer.func1.1.1
	/go/pkg/mod/github.com/grpc-ecosystem/go-grpc-middleware@v1.2.2/chain.go:25
github.com/grpc-ecosystem/go-grpc-middleware/auth.UnaryServerInterceptor.func1
	/go/pkg/mod/github.com/grpc-ecosystem/go-grpc-middleware@v1.2.2/auth/auth.go:47
github.com/grpc-ecosystem/go-grpc-middleware.ChainUnaryServer.func1.1.1
	/go/pkg/mod/github.com/grpc-ecosystem/go-grpc-middleware@v1.2.2/chain.go:25
github.com/grpc-ecosystem/go-grpc-middleware/recovery.UnaryServerInterceptor.func1
	/go/pkg/mod/github.com/grpc-ecosystem/go-grpc-middleware@v1.2.2/recovery/interceptors.go:33
github.com/grpc-ecosystem/go-grpc-middleware.ChainUnaryServer.func1.1.1
	/go/pkg/mod/github.com/grpc-ecosystem/go-grpc-middleware@v1.2.2/chain.go:25
github.com/grpc-ecosystem/go-grpc-middleware.ChainUnaryServer.func1
	/go/pkg/mod/github.com/grpc-ecosystem/go-grpc-middleware@v1.2.2/chain.go:34
github.com/rode/rode/proto/v1alpha1._Rode_EvaluatePolicy_Handler
	rode/rode/proto/v1alpha1/rode_grpc.pb.go:514
google.golang.org/grpc.(*Server).processUnaryRPC
	/go/pkg/mod/google.golang.org/grpc@v1.37.0/server.go:1217
google.golang.org/grpc.(*Server).handleStream
	/go/pkg/mod/google.golang.org/grpc@v1.37.0/server.go:1540
google.golang.org/grpc.(*Server).serveStreams.func1.2
	/go/pkg/mod/google.golang.org/grpc@v1.37.0/server.go:878
```

</details>