### PR TITLE
Configure Rode client to fail on non-temporary dial errors

### DIFF
--- a/common/client.go
+++ b/common/client.go
@@ -45,7 +45,7 @@ func NewRodeClient(config *ClientConfig, dialOptions ...grpc.DialOption) (pb.Rod
 		return nil, errors.New("only one authentication method can be used")
 	}
 
-	dialOptions = append(dialOptions, grpc.WithBlock())
+	dialOptions = append(dialOptions, grpc.WithBlock(), grpc.FailOnNonTempDialError(true))
 
 	if config.Rode.DisableTransportSecurity {
 		dialOptions = append(dialOptions, grpc.WithInsecure())

--- a/common/client_test.go
+++ b/common/client_test.go
@@ -181,6 +181,18 @@ var _ = Describe("client", func() {
 		})
 	})
 
+	When("a non-temporary dial error occurs", func() {
+		BeforeEach(func() {
+			dialOptions = []grpc.DialOption{}
+			expectedConfig.Rode.Host = fake.Word()
+		})
+
+		It("should fail immediately", func() {
+			Expect(actualRodeClient).To(BeNil())
+			Expect(actualError).To(MatchError(ContainSubstring("missing port in address")))
+		})
+	})
+
 	When("OIDC auth is configured", func() {
 		type tokenResponse struct {
 			AccessToken string `json:"access_token"`


### PR DESCRIPTION
This should give better error messages when the gRPC connection is unlikely to ever succeed (e.g., address is missing a port or otherwise invalid). 